### PR TITLE
dump_all_bcsvs: include charset and title in HTML

### DIFF
--- a/dump_all_bcsvs.py
+++ b/dump_all_bcsvs.py
@@ -20,6 +20,10 @@ for filename, row_class in specs.lookup.items():
 	bits = []
 	bits.append('<!DOCTYPE html>')
 	bits.append('<html>')
+	bits.append('<head>')
+	bits.append('<meta charset=utf-8>')
+	bits.append('<title>%s</title>' % filename)
+	bits.append('</meta>')
 	bits.append('<body>')
 	objs = []
 


### PR DESCRIPTION
This improves HTML spec compliance, adds a title to the tab to match the <h1>, and declares the encoding as UTF-8.